### PR TITLE
Added crash handling and environment variables

### DIFF
--- a/OSVR_TrayApp/OSVR_TrayApp/Source/Common.cs
+++ b/OSVR_TrayApp/OSVR_TrayApp/Source/Common.cs
@@ -25,6 +25,8 @@ namespace HDK_TrayApp
                                       REGISTRY_INSTALL_DIRECTORY_KEY = "InstallationDirectory",
                                       REGISTRY_VERSION_KEY = "InstalledVersion";
 
+        public static readonly string ENVIRONMENT_VAR_INSTALL_DIRECTORY = "OSVR_INSTALL_DIR";
+
         public static readonly string TRAY_APP_NAME = "HDK_TrayApp.exe",
                                       SERVICE_NAME = "osvr_server.exe",
                                       TRACKER_VIEW_NAME = "OSVRTrackerView.exe",

--- a/OSVR_TrayApp/OSVR_TrayApp/Source/ContextMenuWYSIWYG.Designer.cs
+++ b/OSVR_TrayApp/OSVR_TrayApp/Source/ContextMenuWYSIWYG.Designer.cs
@@ -140,7 +140,7 @@ namespace HDK_TrayApp
             this.showServerConsoleToolStripMenuItem.Name = "showServerConsoleToolStripMenuItem";
             this.showServerConsoleToolStripMenuItem.Size = new System.Drawing.Size(174, 22);
             this.showServerConsoleToolStripMenuItem.Text = "Show Server Console";
-            this.showServerConsoleToolStripMenuItem.Visible = false;
+            this.showServerConsoleToolStripMenuItem.Visible = true;
             this.showServerConsoleToolStripMenuItem.Click += new System.EventHandler(this.showServerConsoleToolStripMenuItem_Click);
             // 
             // OSVRServerToolStripSeparator

--- a/OSVR_TrayApp/OSVR_TrayApp/Source/ContextMenuWYSIWYG.cs
+++ b/OSVR_TrayApp/OSVR_TrayApp/Source/ContextMenuWYSIWYG.cs
@@ -56,7 +56,7 @@ namespace HDK_TrayApp
             useIRCameraToolStripMenuItem.Enabled = !customServerConfigurationToolStripMenuItem.Checked;
 
             if (start_server)
-                m_server.StartServer();
+                m_server.RestartServer();
 
             if (SteamVRConfig.IsLegacyOSVRDriverInstalled())
                 Common.ShowMessageBox(Common.MSG_STEAMVR_OSVR_LEGACY_DRIVER_DETECTED, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
@@ -138,7 +138,7 @@ namespace HDK_TrayApp
         /// <param name="e"></param>
         private void OSVRContextMenuStrip_Opening(object sender, System.ComponentModel.CancelEventArgs e)
         {
-            if (m_server.Running)
+            if (m_server.serverRunning())
             {
                 startServerToolStripMenuItem.Enabled = false;
                 restartServerToolStripMenuItem.Enabled = true;
@@ -187,7 +187,7 @@ namespace HDK_TrayApp
         /// <param name="e"></param>
         private void startServerToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (!m_server.Running)
+            if (!m_server.serverRunning())
                 m_server.StartServer();
             else
                 m_server.PromptServerRestartAlreadyRunning();
@@ -220,7 +220,7 @@ namespace HDK_TrayApp
         /// <param name="e"></param>
         private void showServerConsoleToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            ShowServerConsole();
+            m_server.ShowServerConsole();
         }
 
         /// <summary>
@@ -284,7 +284,7 @@ namespace HDK_TrayApp
         /// <param name="e"></param>
         private void exitToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (m_server.Running)
+            if (m_server.serverRunning())
                 m_server.StopServer();
 
             OSVRProcessManager.KillProcessByName(Common.TRACKER_VIEW_NAME);

--- a/OSVR_TrayApp/OSVR_TrayApp/Source/OSVRRegistry.cs
+++ b/OSVR_TrayApp/OSVR_TrayApp/Source/OSVRRegistry.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Microsoft.Win32;
+using System;
 
 namespace HDK_TrayApp
 {
@@ -30,15 +31,22 @@ namespace HDK_TrayApp
         {
             string installDirectory = string.Empty;
 
-            RegistryKey registryKey = Registry.LocalMachine.OpenSubKey(Common.REGISTRY_SUB_KEY, false);
+            /// First try to get the directory from the environment variable so as to keep
+            /// consistent with OSVR-Server. If null, then check registry.
+            installDirectory = Environment.GetEnvironmentVariable(Common.ENVIRONMENT_VAR_INSTALL_DIRECTORY);
 
-            if (registryKey != null)
+            if (installDirectory == null)
             {
-                object registryValue = registryKey.GetValue(Common.REGISTRY_INSTALL_DIRECTORY_KEY);
+                RegistryKey registryKey = Registry.LocalMachine.OpenSubKey(Common.REGISTRY_SUB_KEY, false);
 
-                if (registryKey.GetValueKind(Common.REGISTRY_INSTALL_DIRECTORY_KEY) == RegistryValueKind.String)
+                if (registryKey != null)
                 {
-                    installDirectory = registryValue as string;
+                    object registryValue = registryKey.GetValue(Common.REGISTRY_INSTALL_DIRECTORY_KEY);
+
+                    if (registryKey.GetValueKind(Common.REGISTRY_INSTALL_DIRECTORY_KEY) == RegistryValueKind.String)
+                    {
+                        installDirectory = registryValue as string;
+                    }
                 }
             }
 

--- a/OSVR_TrayApp/OSVR_TrayApp/Source/Program.cs
+++ b/OSVR_TrayApp/OSVR_TrayApp/Source/Program.cs
@@ -97,8 +97,10 @@ namespace HDK_TrayApp
             bool msg_trayapp_already_running = trayapp_running && !start_server_arg;
             bool msg_both_already_running = trayapp_running && start_server_arg && server_running;
             
-            if (msg_unmanaged_server_already_running)
+            /// No longer needed warning as server-manager has fault-tolerance
+            /*if (msg_unmanaged_server_already_running)
                 Common.ShowMessageBox(Common.MSG_SERVER_ALREADY_RUNNING_UMANAGED, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            */
 
             if (msg_trayapp_already_running)
                 Common.ShowMessageBox(Common.MSG_TRAYAPP_ALREADY_RUNNING, MessageBoxButtons.OK, MessageBoxIcon.Warning);


### PR DESCRIPTION
Tray application recovers from OSVR-Server crash -- if crash, tray application doesn't get hung up anymore and refreshes the UI via a watchdog timer.

Tray application now checks OSVR_INSTALL_DIR before checking registry, for consistency with OSVR-Core

Tray application now allows server console to be launched from WSIWYG menu